### PR TITLE
Change css selector

### DIFF
--- a/client/app/components/about/about.styl
+++ b/client/app/components/about/about.styl
@@ -1,2 +1,2 @@
-.about
+about
   color red


### PR DESCRIPTION
There's no class "about" in the template so this CSS has no effect.  Just make the selector for elements of type "about" and it works fine (could modify the template as well, but this was easier).
